### PR TITLE
u-boot/arm/rpi4: fix typo in config.txt

### DIFF
--- a/u-boot/arm/rpi4/config.txt
+++ b/u-boot/arm/rpi4/config.txt
@@ -1,3 +1,3 @@
 kernel=u-boot.bin
-uart_2ndstate=1
+uart_2ndstage=1
 enable_uart=1


### PR DESCRIPTION
Hello guys,

I found a typo in config.txt for the Raspberry Pi 4, it contains a setting uart_2ndstate, I believe it should be uart_2ndstage to see th bootloader logs on the serial console.