### PR TITLE
u-boot/arm/rpi3: enable serial console

### DIFF
--- a/u-boot/arm/rpi3/config.txt
+++ b/u-boot/arm/rpi3/config.txt
@@ -1,1 +1,3 @@
 kernel=u-boot.bin
+uart_2ndstage=1
+enable_uart=1


### PR DESCRIPTION
Enable serial console in RPI3, similarly to the RPI4.