### PR TITLE
u-boot/arm/rpi3: add device tree and fixup.dat to SD card

### DIFF
--- a/u-boot/manifest.json
+++ b/u-boot/manifest.json
@@ -24,6 +24,8 @@
 			"https://github.com/haiku/firmware/raw/master/u-boot/arm/rpi3/u-boot.bin",
 			"https://github.com/raspberrypi/firmware/raw/07937c7d48bcd44cc1015c6257ae2cfa5da51298/boot/bootcode.bin",
 			"https://github.com/raspberrypi/firmware/raw/07937c7d48bcd44cc1015c6257ae2cfa5da51298/boot/start.elf",
+			"https://github.com/raspberrypi/firmware/raw/07937c7d48bcd44cc1015c6257ae2cfa5da51298/boot/fixup.dat",
+			"https://github.com/raspberrypi/firmware/raw/07937c7d48bcd44cc1015c6257ae2cfa5da51298/boot/bcm2710-rpi-3-b-plus.dtb",
 			"https://github.com/raspberrypi/firmware/raw/master/boot/LICENCE.broadcom"
 		]
 	},


### PR DESCRIPTION
before:
* firmware complaining that it cannot load the device tree
* u-boot detects only 128 MB RAM

logs:
```
MESS:00:00:01.558901:0: Failed to load Device Tree file 'bcm2710-rpi-3-b.dtb'
MESS:00:00:01.566114:0: gpioman: gpioman_get_pin_num: pin EMMC_ENABLE not defined
MESS:00:00:01.574449:0: uart: Set PL011 baud rate to 103448.300000 Hz
MESS:00:00:01.580737:0: uart: Baud rate change done...
MESS:00:00:01.584167:0: uart: Baud rate

U-Boot 2022.04-rc5-00001-ga00d9f597e (Apr 01 2022 - 09:20:09 +0200)

DRAM:  128 MiB
RPI 3 Model B+ (0xa020d3)

```

after adding device tree binary and fixup.dat:

```
MESS:00:00:01.519538:0: Loading 'bcm2710-rpi-3-b-plus.dtb' to 0x8644c size 0x6736
MESS:00:00:01.678248:0: brfs: File read: 26422 bytes
MESS:00:00:01.681888:0: brfs: File read: /mfs/sd/config.txt
MESS:00:00:03.411786:0: gpioman: gpioman_get_pin_num: pin EMMC_ENABLE not defined
MESS:00:00:03.517758:0: Device tree loaded to 0x2eff9400 (size 0x6b39)
MESS:00:00:03.524029:0: uart: Set PL011 baud rate to 103448.300000 Hz
MESS:00:00:03.530320:0: uart: Baud rate change done...
MESS:00:00:03.533749:0: uart: Baud rate

U-Boot 2022.04-rc5-00001-ga00d9f597e (Apr 01 2022 - 09:20:09 +0200)

DRAM:  948 MiB
RPI 3 Model B+ (0xa020d3)

```
