### PR TITLE
u-boot: add git describe to README

### DIFF
--- a/u-boot/tools/README.template
+++ b/u-boot/tools/README.template
@@ -16,7 +16,7 @@ This section tracks the u-boot revision within this repo.
   * **License:** GPLv2
   * **Source Code:** %%GIT_REPO%%
   * **Date:** %%GIT_DATE%%
-  * **GIT Hash:** %%GIT_HASH%%
+  * **GIT Commit:** %%GIT_HASH%% %%GIT_DESC%%
 * **Toolchain:** http://cgit.haiku-os.org/buildtools/
   * **Toolchain version:** %%CROSS_TOOL_VERSION%%
 * **Build Commands:**

--- a/u-boot/tools/build
+++ b/u-boot/tools/build
@@ -69,6 +69,7 @@ fi
 echo "Calculating dates..."
 GIT_DATE=$(git -C $TMP log -1 --format=%cd)
 GIT_HASH=$(git -C $TMP log -1 --format=%H)
+GIT_DESC=$(git -C $TMP describe)
 
 echo "Locating work..."
 WORK_QUEUE=$(find $TARGET_ARCH/ -mindepth 1 -type d)
@@ -143,6 +144,7 @@ for dir in $WORK_QUEUE; do
 	sed -i "s^%%GIT_REPO%%^$GIT_REPO^g" $dir/README.md
 	sed -i "s^%%GIT_DATE%%^$GIT_DATE^g" $dir/README.md
 	sed -i "s^%%GIT_HASH%%^$GIT_HASH^g" $dir/README.md
+	sed -i "s^%%GIT_DESC%%^$GIT_DESC^g" $dir/README.md
 	sed -i "s^%%BOARD%%^$NAME^g" $dir/README.md
 	sed -i "s^%%FILES%%^$FILES^g" $dir/README.md
 	sed -i "s^%%CONFIG%%^$CONFIG^g" $dir/README.md


### PR DESCRIPTION
I believe it should be possible to build a specific git commit from u-boot repo with the build script
rationale:
* in some cases the latest u-boot might not work quite well
* we might want to use tagged releases e.g. v2022.04 etc.