### PR TITLE
Fix date generation on non-english locale systems

### DIFF
--- a/u-boot/tools/build
+++ b/u-boot/tools/build
@@ -67,7 +67,7 @@ if [ $# -ge 2 ]; then
 fi
 
 echo "Calculating dates..."
-GIT_DATE=$(git -C $TMP log -1 --format=%cd)
+GIT_DATE=$(TZ=UTC0 git -C $TMP log -1 --date=local --format=%cd)
 GIT_HASH=$(git -C $TMP log -1 --format=%H)
 
 echo "Locating work..."
@@ -139,7 +139,7 @@ for dir in $WORK_QUEUE; do
 	# Populate README.md
 	cp tools/README.template $dir/README.md
 	sed -i "s^%%URL%%^$URL^g" $dir/README.md
-	sed -i "s^%%DATE%%^$(TZ=UTC LANG=en_us date)^g" $dir/README.md
+	sed -i "s^%%DATE%%^$(TZ=UTC0 LANG=en_us date)^g" $dir/README.md
 	sed -i "s^%%GIT_REPO%%^$GIT_REPO^g" $dir/README.md
 	sed -i "s^%%GIT_DATE%%^$GIT_DATE^g" $dir/README.md
 	sed -i "s^%%GIT_HASH%%^$GIT_HASH^g" $dir/README.md

--- a/u-boot/tools/build
+++ b/u-boot/tools/build
@@ -139,7 +139,7 @@ for dir in $WORK_QUEUE; do
 	# Populate README.md
 	cp tools/README.template $dir/README.md
 	sed -i "s^%%URL%%^$URL^g" $dir/README.md
-	sed -i "s^%%DATE%%^$(date)^g" $dir/README.md
+	sed -i "s^%%DATE%%^$(TZ=UTC LANG=en_us date)^g" $dir/README.md
 	sed -i "s^%%GIT_REPO%%^$GIT_REPO^g" $dir/README.md
 	sed -i "s^%%GIT_DATE%%^$GIT_DATE^g" $dir/README.md
 	sed -i "s^%%GIT_HASH%%^$GIT_HASH^g" $dir/README.md


### PR DESCRIPTION
* Fix date generation on non-english systems
* Force UTC instead of the developer's timezone

Fixes problem where `date` could generate e.g `pią, 29 lis 2024, 23:55:12 CET` instead of `Fri Nov 29 22:55:12 UTC 2024`

Instead of `Sat Nov 30 00:21:17 2024 +0100` Git can use `Fri Nov 29 23:21:17 2024` to use UTC everywhere